### PR TITLE
Add gitIgnoredAuthors for Apollo Git Bot to default.json

### DIFF
--- a/default.json
+++ b/default.json
@@ -21,7 +21,8 @@
     ],
     "additionalBranchPrefix": "{{parentDir}}-",
     "gitIgnoredAuthors": [
-        "no-reply@studiocms.dev"
+        "no-reply@studiocms.dev",
+        "234251158+apollo-git-bot[bot]@users.noreply.github.com"
     ],
     "prHourlyLimit": 3,
     "rangeStrategy": "bump",


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If applicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ignored commit authors list to include an additional automated account, keeping commit history and activity displays consistent with existing filters.
  * Prevents bot-generated commits from appearing in contribution views, release notes, and activity feeds.
  * No functional changes to the app or workflows; performance unaffected.
  * No action required for users or administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->